### PR TITLE
Allow template string functions that starts html

### DIFF
--- a/syntaxes/template-literals.json
+++ b/syntaxes/template-literals.json
@@ -6,7 +6,7 @@
     "tsx",
     "html"
   ],
-  "injectionSelector": "L:source.js -comment -string, L:source.js -comment -string, L:source.jsx -comment -string,  L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string",
+  "injectionSelector": "L:source.js -comment -string, L:source.js -comment -string, L:source.jsx -comment -string, L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string",
   "injections": {
     "L:source": {
       "patterns": [
@@ -19,13 +19,13 @@
   },
   "patterns": [
     {
-      "begin": "\\s*( `|\\(`|\\[`)",
+      "begin": "\\s*(?:html)?(`|\\(`|\\[`)",
       "beginCaptures": {
-				"1": {
-					"name": "keyword.operator.assignment.js"
+        "1": {
+          "name": "keyword.operator.assignment.js"
         }
       },
-      "end": "(`)",
+      "end": "(`|`\\)|`\\])",
       "patterns": [
         {
           "include": "source.ts#template-substitution-element"


### PR DESCRIPTION
Tools like Prettier formats tagged template literal functions that start with 'html' and 'css' as there marked language. This change allows for both formatting _and_ syntax highlighting.

@see https://prettier.io/blog/2020/08/24/2.1.0.html